### PR TITLE
feat: BandalArt Home UI만 구성

### DIFF
--- a/BandalArt/Projects/App/Resources/Assets.xcassets/sub.colorset/Contents.json
+++ b/BandalArt/Projects/App/Resources/Assets.xcassets/sub.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.153",
+          "green" : "0.094",
+          "red" : "0.067"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BandalArt/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/BandalArt/Projects/App/Sources/Application/SceneDelegate.swift
@@ -5,8 +5,10 @@
 //  Created by Sang hun Lee on 2023/07/18.
 //
 
-import Foundation
 import UIKit
+
+import MainFeature
+import HomeFeature
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -17,7 +19,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         willConnectTo session: UISceneSession,
         options connectionOptions: UIScene.ConnectionOptions
     ) {
-      guard let scene = (scene as? UIWindowScene) else { return }
+        guard let scene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: scene)
+
+        let vc = BandalArtHomeViewController()
+        let nav = MainNavigationController(rootViewController: vc)
+        window?.rootViewController = nav
+        window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/BandalArt/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/BandalArt/Projects/App/Sources/Application/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
 
-        let vc = BandalArtHomeViewController()
+        let vc = HomeViewController()
         let nav = MainNavigationController(rootViewController: vc)
         window?.rootViewController = nav
         window?.makeKeyAndVisible()

--- a/BandalArt/Projects/Feature/Home/Sources/BandalArtCell.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/BandalArtCell.swift
@@ -27,7 +27,7 @@ final class BandalArtCell: UICollectionViewCell {
         var backGroundColor: UIColor {
             switch self {
             case .task: return .systemBackground
-            case .subGoal: return .gray900
+            case .subGoal: return .sub
             }
         }
         

--- a/BandalArt/Projects/Feature/Home/Sources/BandalArtCell.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/BandalArtCell.swift
@@ -21,8 +21,8 @@ final class BandalArtCell: UICollectionViewCell {
     }
     
     enum Mode: Equatable {
-        case task(Status)
-        case subGoal(Status)
+        case task
+        case subGoal
         
         var backGroundColor: UIColor {
             switch self {
@@ -48,7 +48,16 @@ final class BandalArtCell: UICollectionViewCell {
 
     static let identifier: String = "BasicCell"
 
+    //작성 전 컴포넌트
+    private let placeHolderView = BandalartPlaceHolderView()
+    
+    //작성 후 컴포넌트
     private let descriptionLabel = UILabel()
+    
+    //완료 후 컴포넌트
+    private let completionView = BandalartCompletionView()
+    
+    var mode: Mode = .task
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -69,19 +78,118 @@ final class BandalArtCell: UICollectionViewCell {
         descriptionLabel.textColor = .gray900
         descriptionLabel.font = .systemFont(ofSize: 12, weight: .medium)
         
-        contentView.addSubview(descriptionLabel)
-        descriptionLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(6)
-            make.bottom.equalToSuperview().offset(-6)
-            make.leading.equalToSuperview().offset(5)
-            make.trailing.equalToSuperview().offset(-5)
+        contentView.addSubview(placeHolderView)
+        placeHolderView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
 
-    func configure(title: String?, mode: Mode) {
-        descriptionLabel.text = title
+    func configure(title: String?, mode: Mode, status: Status) {
         contentView.backgroundColor = mode.backGroundColor
-        descriptionLabel.font = mode.font
-        descriptionLabel.textColor = mode.textColor
+        self.mode = mode
+        
+        switch status {
+        case .empty:
+            descriptionLabel.removeFromSuperview()
+            placeHolderView.configure(mode: mode)
+            
+        case .created, .completed:
+            placeHolderView.removeFromSuperview()
+            contentView.addSubview(descriptionLabel)
+            descriptionLabel.snp.makeConstraints { make in
+                make.top.equalToSuperview().offset(6)
+                make.bottom.equalToSuperview().offset(-6)
+                make.leading.equalToSuperview().offset(5)
+                make.trailing.equalToSuperview().offset(-5)
+            }
+            descriptionLabel.text = title
+            descriptionLabel.font = mode.font
+            descriptionLabel.textColor = mode.textColor
+        }
+        
+        guard status == .completed else { return }
+        setCompleted()
+    }
+    
+    func setCompleted() {
+        if mode == .task {
+            contentView.backgroundColor = .gray300
+        }
+        contentView.addSubview(completionView)
+        completionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+final class BandalartCompletionView: UIView {
+    
+    private let checkImageView = UIImageView(image: .init(systemName: "checkmark.circle"))
+    
+    public init() {
+        super.init(frame: .zero)
+        setUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        checkImageView.tintColor = .gray500
+        layer.cornerRadius = 10
+        backgroundColor = .systemBackground.withAlphaComponent(0.6)
+        checkImageView.layer.cornerRadius = 10
+        checkImageView.backgroundColor = .systemBackground
+        
+        addSubview(checkImageView)
+        checkImageView.snp.makeConstraints { make in
+            make.bottom.trailing.equalToSuperview().offset(-4)
+            make.width.height.equalTo(20)
+        }
+    }
+}
+
+final class BandalartPlaceHolderView: UIView {
+    
+    private let stackView = UIStackView()
+    private let plusImageView = UIImageView(image: .init(systemName: "plus"))
+    
+    public init() {
+        super.init(frame: .zero)
+        setUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        backgroundColor = .clear
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        
+        plusImageView.tintColor = .gray500
+        plusImageView.contentMode = .center
+        
+        addSubview(stackView)
+        stackView.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().offset(12)
+            make.bottom.trailing.equalToSuperview().offset(-12)
+        }
+        stackView.addArrangedSubview(plusImageView)
+    }
+    
+    func configure(mode: BandalArtCell.Mode) {
+        self.plusImageView.tintColor = mode.textColor
+        
+        guard mode == .subGoal else { return }
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 12, weight: .bold)
+        label.text = "서브목표"
+        label.textColor = mode.textColor
+        stackView.insertArrangedSubview(label, at: 0)
     }
 }

--- a/BandalArt/Projects/Feature/Home/Sources/Home.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/Home.swift
@@ -1,8 +1,0 @@
-//
-//  FeatureHome.swift
-//  ProjectDescriptionHelpers
-//
-//  Created by Sang hun Lee on 2023/07/19.
-//
-
-import Foundation

--- a/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
@@ -56,6 +56,7 @@ public final class HomeViewController: UIViewController {
         
         // 임시 세팅
         centerLabel.text = "완벽한 2024년"
+        centerLabel.textColor = .sub
         bandalartNameLabel.text = "완벽한 2024년"
         bandalartNameLabel.textColor = .gray900
         emojiView.setEmoji(with: "😎")
@@ -156,7 +157,6 @@ private extension HomeViewController {
         centerLabel.numberOfLines = 3
         centerLabel.textAlignment = .center
         centerLabel.lineBreakMode = .byWordWrapping
-        centerLabel.textColor = .gray900
         centerLabel.font = .systemFont(ofSize: 13, weight: .bold)
         
         bandalartView.backgroundColor = .clear

--- a/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
@@ -63,7 +63,7 @@ public final class HomeViewController: UIViewController {
     }
     
     @objc private func moreButtonTap() {
-        print("공유하기")
+        print("더보기")
     }
     
     @objc private func shareButtonTap() {
@@ -94,12 +94,12 @@ extension HomeViewController: UICollectionViewDelegate,
             return UICollectionViewCell()
         }
         let status: BandalArtCell.Status = .created
-        let mode: BandalArtCell.Mode = collectionView.tag == indexPath.item ? .subGoal(status) : .task(status)
+        let mode: BandalArtCell.Mode = collectionView.tag == indexPath.item ? .subGoal : .task
         var title = "네트워킹 모임 참여"
         if case .subGoal = mode {
             title = "제테크"
         }
-        cell.configure(title: title, mode: mode)
+        cell.configure(title: title, mode: mode, status: status)
         return cell
     }
 

--- a/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
@@ -7,10 +7,28 @@
 
 import UIKit
 import Components
+import Util
 
 import SnapKit
 
 public final class HomeViewController: UIViewController {
+    
+    public init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // 반다라트 헤더
+    private let emojiView = EmojiView()
+    private let bandalartNameLabel = UILabel()
+    private let pencilAeccessaryImageView = UIImageView(image: .init(systemName: "pencil.circle.fill"))
+    private let moreButton = UIButton()
+    
+    private let progressDescriptionLabel = UILabel()
+    private let progressView = UIProgressView()
 
     // 반다라트 표 컨테이너 뷰
     private let bandalartView = UIView()
@@ -30,20 +48,34 @@ public final class HomeViewController: UIViewController {
     
     private let shareButton = UIButton()
 
-    public init() {
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.setNavigationBar()
         self.setConfigure()
         self.setConstraints()
+        
+        // 임시 세팅
         centerLabel.text = "완벽한 2024년"
+        bandalartNameLabel.text = "완벽한 2024년"
+        bandalartNameLabel.textColor = .gray900
+        emojiView.setEmoji(with: "😎")
+        pencilAeccessaryImageView.isHidden = true
+    }
+    
+    @objc private func moreButtonTap() {
+        print("공유하기")
+    }
+    
+    @objc private func shareButtonTap() {
+        print("공유하기")
+    }
+    
+    @objc private func addBarButtonTap() {
+        print("추가하기")
+    }
+    
+    @objc private func logoBarButtonTap() {
+        print("반다라트")
     }
 }
 
@@ -95,18 +127,29 @@ extension HomeViewController: UICollectionViewDelegate,
 
 // MARK: - Private func.
 private extension HomeViewController {
-    
-    @objc func addBarButtonTap() {
-        print("추가하기")
-    }
-    
-    @objc func logoBarButtonTap() {
-        print("반다라트")
-    }
 
     func setConfigure() {
         view.backgroundColor = .gray50
-
+        
+        pencilAeccessaryImageView.tintColor = .gray900
+        pencilAeccessaryImageView.isUserInteractionEnabled = false
+        bandalartNameLabel.text = "메인 목표를 입력해주세요"
+        bandalartNameLabel.textColor = .gray300
+        bandalartNameLabel.textAlignment = .center
+        bandalartNameLabel.font = .boldSystemFont(ofSize: 20)
+        
+        moreButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
+        moreButton.tintColor = .gray500
+        moreButton.addTarget(self, action: #selector(moreButtonTap),
+                             for: .touchUpInside)
+        
+        progressDescriptionLabel.text = "달성률 (0%)"
+        progressDescriptionLabel.textColor = .gray600
+        progressDescriptionLabel.font = .systemFont(ofSize: 12, weight: .medium)
+        progressView.trackTintColor = .gray100
+        progressView.progressTintColor = .mint
+        progressView.progress = 0.3
+        
         centerView.backgroundColor = .mint
         centerView.layer.cornerRadius = 10
         
@@ -143,9 +186,35 @@ private extension HomeViewController {
         rightTopCollectionView.tag = 2
         leftBottomCollectionView.tag = 3
         rightBottomCollectionView.tag = 1
+        
+        var config = UIButton.Configuration.plain()
+        config.title = "공유하기"
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = .systemFont(ofSize: 12, weight: .bold)
+            return outgoing
+        }
+        config.image = UIImage(systemName: "square.and.arrow.up")
+        config.imagePadding = 4
+        config.baseForegroundColor = .gray900
+        config.baseBackgroundColor = .gray100
+        config.contentInsets = .init(top: 8, leading: 16,
+                                     bottom: 8, trailing: 16)
+        shareButton.configuration = config
+        shareButton.addTarget(self, action: #selector(shareButtonTap),
+                            for: .touchUpInside)
+        shareButton.layer.cornerRadius = 12
+        shareButton.backgroundColor = .gray100
+        shareButton.layer.masksToBounds = true
     }
 
     func setConstraints() {
+        view.addSubview(emojiView)
+        view.addSubview(pencilAeccessaryImageView)
+        view.addSubview(bandalartNameLabel)
+        view.addSubview(moreButton)
+        view.addSubview(progressDescriptionLabel)
+        view.addSubview(progressView)
         view.addSubview(bandalartView)
         view.addSubview(shareButton)
         centerView.addSubview(centerLabel)
@@ -155,15 +224,55 @@ private extension HomeViewController {
         bandalartView.addSubview(rightTopCollectionView)
         bandalartView.addSubview(leftBottomCollectionView)
         bandalartView.addSubview(rightBottomCollectionView)
-
+        
+        shareButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-32)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(110)
+            make.height.equalTo(36)
+        }
         centerLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(6)
             make.bottom.equalToSuperview().offset(-6)
             make.leading.equalToSuperview().offset(5)
             make.trailing.equalToSuperview().offset(-5)
         }
+        emojiView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(24)
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(52)
+        }
+        pencilAeccessaryImageView.snp.makeConstraints { make in
+            make.width.height.equalTo(18)
+            make.bottom.trailing.equalTo(emojiView).offset(4)
+        }
+        bandalartNameLabel.snp.makeConstraints { make in
+            make.top.equalTo(emojiView.snp.bottom).offset(16)
+            make.centerX.equalToSuperview()
+            make.leading.equalToSuperview().offset(20)
+            make.leading.equalToSuperview().offset(-44)
+        }
+        moreButton.snp.makeConstraints { make in
+            make.centerY.equalTo(bandalartNameLabel)
+            make.trailing.equalToSuperview().offset(-16)
+            make.height.equalTo(bandalartNameLabel)
+            make.width.equalTo(moreButton.snp.height)
+        }
+        progressDescriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(bandalartNameLabel.snp.bottom).offset(26)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            
+        }
+        progressView.snp.makeConstraints { make in
+            make.top.equalTo(progressDescriptionLabel.snp.bottom).offset(8)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            make.height.equalTo(8)
+        }
         bandalartView.snp.makeConstraints { make in
-            make.top.leading.equalTo(view.safeAreaLayoutGuide).offset(15)
+            make.top.equalTo(progressView.snp.bottom).offset(18)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(15)
             make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-15)
             make.height.equalTo(bandalartView.snp.width)
         }

--- a/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/HomeViewController.swift
@@ -10,7 +10,7 @@ import Components
 
 import SnapKit
 
-public final class BandalArtHomeViewController: UIViewController {
+public final class HomeViewController: UIViewController {
 
     // 반다라트 표 컨테이너 뷰
     private let bandalartView = UIView()
@@ -40,13 +40,14 @@ public final class BandalArtHomeViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        self.setNavigationBar()
         self.setConfigure()
         self.setConstraints()
         centerLabel.text = "완벽한 2024년"
     }
 }
 
-extension BandalArtHomeViewController: UICollectionViewDelegate,
+extension HomeViewController: UICollectionViewDelegate,
                                        UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
 
     public func collectionView(_ collectionView: UICollectionView,
@@ -93,10 +94,17 @@ extension BandalArtHomeViewController: UICollectionViewDelegate,
 }
 
 // MARK: - Private func.
-private extension BandalArtHomeViewController {
+private extension HomeViewController {
+    
+    @objc func addBarButtonTap() {
+        print("추가하기")
+    }
+    
+    @objc func logoBarButtonTap() {
+        print("반다라트")
+    }
 
     func setConfigure() {
-        navigationItem.title = "홈"
         view.backgroundColor = .gray50
 
         centerView.backgroundColor = .mint
@@ -130,7 +138,7 @@ private extension BandalArtHomeViewController {
             }
         }
         
-        // collecionView의 tag는 서브 목표의 Cell Index.
+        //Tag는 서브 목표 Cell Index를 나타냄. 서브 목표의 UI구성에 사용.
         leftTopCollectionView.tag = 4
         rightTopCollectionView.tag = 2
         leftBottomCollectionView.tag = 3
@@ -139,6 +147,7 @@ private extension BandalArtHomeViewController {
 
     func setConstraints() {
         view.addSubview(bandalartView)
+        view.addSubview(shareButton)
         centerView.addSubview(centerLabel)
         
         bandalartView.addSubview(centerView)
@@ -186,6 +195,32 @@ private extension BandalArtHomeViewController {
             make.trailing.equalTo(rightTopCollectionView.snp.leading).offset(-2)
             make.bottom.equalTo(rightBottomCollectionView.snp.top).offset(-2)
         }
+    }
+    
+    func setNavigationBar() {
+        // set Right Navigation Item.
+        var config = UIButton.Configuration.plain()
+        config.title = "추가"
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = .systemFont(ofSize: 16, weight: .bold)
+            return outgoing
+        }
+        config.image = UIImage(systemName: "plus")
+        config.baseForegroundColor = .gray600
+        let addButton = UIButton(configuration: config)
+        addButton.addTarget(self, action: #selector(addBarButtonTap),
+                            for: .touchUpInside)
+        navigationItem.rightBarButtonItem = .init(customView: addButton)
+        
+        // set Left Navigation Item.
+        let logoButton = UIButton()
+        logoButton.setTitle("반다라트", for: .normal)
+        logoButton.setTitleColor(.gray900, for: .normal)
+        logoButton.titleLabel?.font = .systemFont(ofSize: 28, weight: .regular)
+        logoButton.addTarget(self, action: #selector(logoBarButtonTap),
+                             for: .touchUpInside)
+        navigationItem.leftBarButtonItem = .init(customView: logoButton)
     }
 
     enum UI {

--- a/BandalArt/Projects/Feature/Home/Sources/HomeViewModel.swift
+++ b/BandalArt/Projects/Feature/Home/Sources/HomeViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  HomeViewModel.swift
+//  HomeFeature
+//
+//  Created by Youngmin Kim on 2023/07/31.
+//  Copyright © 2023 Otani. All rights reserved.
+//
+
+import Foundation

--- a/BandalArt/Projects/Feature/Main/Sources/Main.swift
+++ b/BandalArt/Projects/Feature/Main/Sources/Main.swift
@@ -1,8 +1,0 @@
-//
-//  Main.swift
-//  ProjectDescriptionHelpers
-//
-//  Created by Sang hun Lee on 2023/07/21.
-//
-
-import Foundation

--- a/BandalArt/Projects/Feature/Main/Sources/MainNavigationController.swift
+++ b/BandalArt/Projects/Feature/Main/Sources/MainNavigationController.swift
@@ -1,0 +1,28 @@
+//
+//  MainNavigationController.swift
+//  MainFeature
+//
+//  Created by Youngmin Kim on 2023/07/28.
+//  Copyright © 2023 Otani. All rights reserved.
+//
+
+import UIKit
+
+public final class MainNavigationController: UINavigationController {
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/BandalArt/Projects/Shared/Components/Sources/AppColor.swift
+++ b/BandalArt/Projects/Shared/Components/Sources/AppColor.swift
@@ -11,6 +11,7 @@ import Foundation
 enum AppColor: String {
 
     case mint
+    case sub
 
     case gray50
     case gray100

--- a/BandalArt/Projects/Shared/Components/Sources/Extension/UIColor+Ex.swift
+++ b/BandalArt/Projects/Shared/Components/Sources/Extension/UIColor+Ex.swift
@@ -13,6 +13,9 @@ public extension UIColor {
     static var mint: UIColor {
         return UIColor(named: AppColor.mint.rawValue)!
     }
+    static var sub: UIColor {
+        return UIColor(named: AppColor.sub.rawValue)!
+    }
     static var gray50: UIColor {
         return UIColor(named: AppColor.gray50.rawValue)!
     }


### PR DESCRIPTION
### 🟧 이슈 번호

Close #12 


### 🟨 간단 설명

> 구현 내용 및 작업 했던 내역 또는 이미지 첨부 길어지면 토글버튼으로 넣기

- [x] UI만구성, 네트워크 연결 x, 이미지 에셋 추가 x, 폰트 적용x


#### Screenshots
<p>
<img src="https://github.com/Nexters/BandalArt-iOS/assets/42762236/21bb8d08-15a2-4d65-b277-e71b4d0a0a77" width="250">
<img src="https://github.com/Nexters/BandalArt-iOS/assets/42762236/4e8a684b-3e74-4a0b-8a68-b56dda452e25" width="250">
<img src="https://github.com/Nexters/BandalArt-iOS/assets/42762236/b09b9eab-6d1d-4d5e-9833-f8c07b274a96" width="250">
</p>


### 🟩 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 🟦 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

### 🟪 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 셀 크기 계산하는 부분 (flowLayout)
- tag로 subGoal 셀구성
- 셀의 mode, status enum

<br/><br/>
